### PR TITLE
fix: update walker entry syntax in a2a-example

### DIFF
--- a/a2a-example/reviewer_app/reviewer_app.jac
+++ b/a2a-example/reviewer_app/reviewer_app.jac
@@ -122,8 +122,8 @@ node reviewer_agent {
 # ============================================================================
 
 walker :pub get_agent_card {
-    can start with `root entry {
-        visit [-->(`?reviewer_agent)];
+    can start with Root entry {
+        visit [-->(?:reviewer_agent)];
     }
 
     can return_card with reviewer_agent entry {
@@ -135,8 +135,8 @@ walker :pub a2a_tasks_send {
     has skill_id: str = "review_content",
         params: dict = {};
 
-    can start with `root entry {
-        visit [-->(`?reviewer_agent)];
+    can start with Root entry {
+        visit [-->(?:reviewer_agent)];
     }
 
     can execute with reviewer_agent entry {
@@ -156,8 +156,8 @@ walker :pub review_content {
     has content: str = "",
         tone: str = "professional";
 
-    can start with `root entry {
-        visit [-->(`?reviewer_agent)];
+    can start with Root entry {
+        visit [-->(?:reviewer_agent)];
     }
 
     can review with reviewer_agent entry {
@@ -170,8 +170,8 @@ walker :pub review_content {
 }
 
 walker :pub init_agent {
-    can start with `root entry {
-        if not [-->(`?reviewer_agent)] {
+    can start with Root entry {
+        if not [-->(?:reviewer_agent)] {
             here ++> reviewer_agent();
             print("Created: reviewer_agent");
         }

--- a/a2a-example/writer_app/writer_app.jac
+++ b/a2a-example/writer_app/writer_app.jac
@@ -170,8 +170,8 @@ node writer_agent {
 # ============================================================================
 
 walker :pub get_agent_card {
-    can start with `root entry {
-        visit [-->(`?writer_agent)];
+    can start with Root entry {
+        visit [-->(?:writer_agent)];
     }
 
     can return_card with writer_agent entry {
@@ -180,8 +180,8 @@ walker :pub get_agent_card {
 }
 
 walker :pub discover_reviewer {
-    can start with `root entry {
-        visit [-->(`?writer_agent)];
+    can start with Root entry {
+        visit [-->(?:writer_agent)];
     }
 
     can discover with writer_agent entry {
@@ -193,8 +193,8 @@ walker :pub a2a_tasks_send {
     has skill_id: str = "create_content",
         params: dict = {};
 
-    can start with `root entry {
-        visit [-->(`?writer_agent)];
+    can start with Root entry {
+        visit [-->(?:writer_agent)];
     }
 
     can execute with writer_agent entry {
@@ -214,8 +214,8 @@ walker :pub create_content {
     has topic: str = "artificial intelligence",
         tone: str = "professional";
 
-    can start with `root entry {
-        visit [-->(`?writer_agent)];
+    can start with Root entry {
+        visit [-->(?:writer_agent)];
     }
 
     can write with writer_agent entry {
@@ -228,8 +228,8 @@ walker :pub create_content {
 }
 
 walker :pub init_agent {
-    can start with `root entry {
-        if not [-->(`?writer_agent)] {
+    can start with Root entry {
+        if not [-->(?:writer_agent)] {
             here ++> writer_agent();
             print("Created: writer_agent");
         }


### PR DESCRIPTION
This pull request updates both the reviewer and writer agent applications to standardize the walker entry syntax and agent reference patterns. The changes enhance code consistency and clarity by replacing backtick-enclosed lowercase `root entry` and agent references with capitalized `Root entry` and a new agent reference syntax.

Standardization of walker entry syntax:

* Replaced all instances of `root entry` with `Root entry` in walker definitions for both reviewer and writer apps

Update of agent reference syntax:

* Changed agent references from ``?agent_name`` to `?:agent_name` in all walker transitions