### PR TITLE
refactor: migrate to new jac type syntax in content_creator approach_1

### DIFF
--- a/content_creator/byLLM/approach_1/agent_core.jac
+++ b/content_creator/byLLM/approach_1/agent_core.jac
@@ -24,14 +24,14 @@ walker get_all_sessions {
     obj __specs__ {
         static has auth: bool = False;
     }
-    can get_all_sessions with `root entry {
-        memory_list = [here --> (`?Memory)];
+    can get_all_sessions with Root entry {
+        memory_list = [here --> (?:Memory)];
         if not memory_list {
             report "No sessions found.";
             disengage;
         }
         memory = memory_list[0];
-        session_list = [memory --> (`?Session)];
+        session_list = [memory --> (?:Session)];
         report [{
             "id": jid(session),
             "created_at": session.created_at

--- a/content_creator/byLLM/approach_1/main.impl.jac
+++ b/content_creator/byLLM/approach_1/main.impl.jac
@@ -17,19 +17,19 @@ impl agent.call_next_agent {
         disengage;
 
     } elif next_agent == AgentTypes.PLANNER_AGENT {
-        plan_handling = [root --> (`?PlanerHandling)][0];
+        plan_handling = [root --> (?:PlanerHandling)][0];
         planner_agent(session=self.session, user_input=user_input) spawn plan_handling;
 
     } elif next_agent == AgentTypes.WRITER_AGENT {
-        writer_handling = [root --> (`?WriterHandling)][0];
+        writer_handling = [root --> (?:WriterHandling)][0];
         writer_agent(session=self.session, user_input=user_input) spawn writer_handling;
 
     } elif next_agent == AgentTypes.REVIEW_AGENT {
-        review_handling = [root --> (`?ReviewHandling)][0];
+        review_handling = [root --> (?:ReviewHandling)][0];
         review_agent(session=self.session, user_input=user_input) spawn review_handling;
 
     } elif next_agent == AgentTypes.MEDIA_AGENT {
-        media_handling = [root --> (`?MediaHandling)][0];
+        media_handling = [root --> (?:MediaHandling)][0];
         media_agent(session=self.session) spawn media_handling;
     } else {
         print("No valid next agent found, stopping execution.");
@@ -38,7 +38,7 @@ impl agent.call_next_agent {
 }
 
 impl SupervisorAgent.supervise {
-    memory_list = [root --> (`?Memory)];
+    memory_list = [root --> (?:Memory)];
     if not memory_list {
         memory_list = root ++> Memory();
     }
@@ -50,16 +50,16 @@ impl SupervisorAgent.supervise {
         self.session = &(self.session_id);
     }
 
-    if not [root --> (`?PlanerHandling)] {
+    if not [root --> (?:PlanerHandling)] {
         root ++> PlanerHandling();
     }
-    if not [root --> (`?WriterHandling)] {
+    if not [root --> (?:WriterHandling)] {
         root ++> WriterHandling();
     }
-    if not [root --> (`?ReviewHandling)] {
+    if not [root --> (?:ReviewHandling)] {
         root ++> ReviewHandling();
     }
-    if not [root --> (`?MediaHandling)] {
+    if not [root --> (?:MediaHandling)] {
         root ++> MediaHandling();
     }
     

--- a/content_creator/byLLM/approach_1/main.jac
+++ b/content_creator/byLLM/approach_1/main.jac
@@ -53,7 +53,7 @@ walker SupervisorAgent(agent) {
         static has auth: bool = False;
     }
     def find_next_agent(user_input: dict, current_agent_response: str, current_state: dict) -> AgentTypes by llm();
-    can supervise with `root entry;
+    can supervise with Root entry;
 }
 
 walker planner_agent(agent) {


### PR DESCRIPTION
* Updated all queries for agent handling components (e.g., `PlanerHandling`, `WriterHandling`, `ReviewHandling`, `MediaHandling`, `Memory`, and `Session`) to use the `(?:Type)` syntax instead of the legacy ``(`?Type)``

* Changed walker and agent entrypoint definitions from using backtick-based syntax (e.g., ``can get_all_sessions with `root entry``) to the new format (e.g., `can get_all_sessions with Root entry`).