### PR TITLE
Apply latest changes to the Content Creator Application(Approach 2) 

### DIFF
--- a/content_creator/byLLM/approach_2/agent_core.jac
+++ b/content_creator/byLLM/approach_2/agent_core.jac
@@ -109,8 +109,8 @@ walker supervisor {
         return None;
     }
     def route_to_agent(utterance: str, history: str) -> AgentTypes abs;
-    can supervise with `root entry {
-        memory_list = [root --> (`?Memory)];
+    can supervise with Root entry {
+        memory_list = [root --> (?:Memory)];
         if not memory_list {
             memory_list = root ++> Memory();
         }
@@ -168,7 +168,7 @@ walker agent {
         return None;
     }
     def route_to_node(utterance: str, history: str) -> RoutingNodes abs;
-    can execute with `root entry {
+    can execute with Root entry {
         self.session = &(self.session_id);
         routed_node = self.route_to_node(self.utterance, self.session.get_history());
         node_cls = self.get_node_class(routed_node.value);
@@ -177,7 +177,7 @@ walker agent {
             return;
         }
         node_inst = node_cls();
-        visit [-->(`?node_cls)] else {
+        visit [-->](?:node_cls) else {
             attached_routed_node = here ++> node_inst;
             visit attached_routed_node;
         }
@@ -188,14 +188,14 @@ walker get_all_sessions {
     obj __specs__ {
         static has auth: bool = False;
     }
-    can get_all_sessions with `root entry {
-        memory_list = [here --> (`?Memory)];
+    can get_all_sessions with Root entry {
+        memory_list = [here --> (?:Memory)];
         if not memory_list {
             report "No sessions found.";
             disengage;
         }
         memory = memory_list[0];
-        session_list = [memory --> (`?Session)];
+        session_list = [memory --> (?:Session)];
         report [{
             "id": jid(session),
             "created_at": session.created_at

--- a/content_creator/byLLM/approach_2/main.jac
+++ b/content_creator/byLLM/approach_2/main.jac
@@ -5,7 +5,7 @@ import from agent_core { Memory, Session }
 import from byllm.llm { Model }
 import sys;
 
-glob llm = Model(model_name="gpt-4o", verbose=False);
+glob llm = Model(model_name="gpt-4o-mini", config={"verbose": False});
 
 
 enum AgentTypes {
@@ -74,7 +74,7 @@ node PlannerAgent(Agent) {
         visitor.session.current_state["planning_complete"] = True;
         
         print("Plan created, moving to writing stage");
-        visit [<--](`?Supervisor);
+        visit [<--](?:Supervisor);
     }
 }
   
@@ -101,7 +101,7 @@ node WriterAgent(Agent) {
         visitor.session.current_state["review_complete"] = False;
         
         print("Content created, moving to review stage");
-        visit [<--](`?Supervisor);
+        visit [<--](?:Supervisor);
     }
 }
 
@@ -133,7 +133,7 @@ node ReviewAgent(Agent) {
         
         if not content {
             print("No content to review, returning to supervisor");
-            visit [<--](`?Supervisor);
+            visit [<--](?:Supervisor);
             return;
         }
         
@@ -168,7 +168,7 @@ node ReviewAgent(Agent) {
             }
         }
         
-        visit [<--](`?Supervisor);
+        visit [<--](?:Supervisor);
     }
 }
 
@@ -206,12 +206,12 @@ walker agent_executor {
             
             disengage;
         } else {
-            visit [-->](`?Agent)(?agent_type == next_agent);
+            visit [-->](?:Agent, agent_type == next_agent);
         }
     }
 
-    can init_graph with `root entry {
-        memory_list = [root --> (`?Memory)];
+    can init_graph with Root entry {
+        memory_list = [root --> (?:Memory)];
         if not memory_list {
             memory_list = root ++> Memory();
         }
@@ -229,7 +229,7 @@ walker agent_executor {
         
         print(f"Starting workflow for: {self.utterance}");
 
-        visit [-->](`?Supervisor) else {
+        visit [-->](?:Supervisor) else {
             router_node = here ++> Supervisor();
             router_node ++> PlannerAgent();
             router_node ++> WriterAgent(); 


### PR DESCRIPTION
This pull request focuses on improving the syntax and configuration of agent routing and execution in the content creator workflow. The main changes involve standardizing the visit and entry syntax for agent navigation, updating the model configuration, and ensuring consistent handling of memory and session objects.

Syntax and Routing Improvements:

* Standardized the visit syntax throughout the codebase, replacing old forms like `[-->](`?Agent)` and `[<--](`?Supervisor)` with the new form `[-->](?:Agent)` and `[<--](?:Supervisor)` for clearer and more consistent agent navigation. [[1]](diffhunk://#diff-875cb749b027fc61ae99c01aee53643463e857c9c55bf2eecd688ca98cfee187L180-R180) [[2]](diffhunk://#diff-c3288c501fe391eff60539241a82c335cd8013f1bc869ed7e0ec1a0827600d66L77-R77) [[3]](diffhunk://#diff-c3288c501fe391eff60539241a82c335cd8013f1bc869ed7e0ec1a0827600d66L104-R104) [[4]](diffhunk://#diff-c3288c501fe391eff60539241a82c335cd8013f1bc869ed7e0ec1a0827600d66L136-R136) [[5]](diffhunk://#diff-c3288c501fe391eff60539241a82c335cd8013f1bc869ed7e0ec1a0827600d66L171-R171) [[6]](diffhunk://#diff-c3288c501fe391eff60539241a82c335cd8013f1bc869ed7e0ec1a0827600d66L209-R214) [[7]](diffhunk://#diff-c3288c501fe391eff60539241a82c335cd8013f1bc869ed7e0ec1a0827600d66L232-R232)
* Updated entry point syntax from ``root entry {`` to `Root entry {` in walker definitions for improved readability and uniformity. 

Memory and Session Handling:

* Updated memory and session list retrieval syntax to use `[root --> (?:Memory)]` and `[memory --> (?:Session)]`, replacing the previous forms for more robust querying and object handling. 

Model Configuration:

* Changed the global `llm` initialization to use `gpt-4o-mini` with a new config dictionary for verbosity, instead of the previous verbose parameter.

These changes collectively enhance the maintainability, clarity, and reliability of agent routing and session management in the workflow.