### PR TITLE
fix: update Travel_planner application backend with the latest jaseci stack

### DIFF
--- a/Travel_planner/BE/agent_brain.jac
+++ b/Travel_planner/BE/agent_brain.jac
@@ -1,6 +1,6 @@
 import from byllm.llm { Model }
 
-glob llm = Model(model_name="gpt-4o-mini", verbose=False);
+glob llm = Model(model_name="gpt-4o-mini", config={"verbose": False});
 
 """
 Defines the types of agents in the system:

--- a/Travel_planner/BE/agent_core.jac
+++ b/Travel_planner/BE/agent_core.jac
@@ -5,7 +5,7 @@ import from agent_brain { brain, AgentType, AgentRole, AgentResult }
 import from agent_memory { memory }
 
 # Global LLM instance used for agent reasoning and decision-making
-glob llm = Model(model_name="gpt-4o-mini", verbose=False);
+glob llm = Model(model_name="gpt-4o-mini", config={"verbose": False});
 
 
 """
@@ -199,7 +199,7 @@ node BaseAgent {
         }
 
         if should_delegate {
-            connected_agents = [-->(`?BaseAgent)] + [<--(`?BaseAgent)];
+            connected_agents = [-->(?:BaseAgent)] + [<--(?:BaseAgent)];
 
             # Decide which agent should handle the next step
             next_agent_data = self.brain.decide_next_agent(
@@ -221,8 +221,8 @@ node BaseAgent {
             print();
 
             # Visit next agent based on role
-            visit [-->(`?BaseAgent: agent_role == next_agent)] else {
-                visit [<--(`?BaseAgent: agent_role == next_agent)];
+            visit [-->(?:BaseAgent, agent_role == next_agent)] else {
+                visit [<--(?:BaseAgent, agent_role == next_agent)];
             }
         } else {
             self.brain.store_agent_result(self.agent_role, self.final_result);  # Store result globally

--- a/Travel_planner/BE/main.jac
+++ b/Travel_planner/BE/main.jac
@@ -9,8 +9,8 @@ walker chat {
         static has auth: bool = False;
     }
 
-    can execute with `root entry {
-        if [-->(`?Session)] {
+    can execute with Root entry {
+        if [-->(?:Session)] {
             visit [-->];
         } else {
             new_session = here ++> Session();
@@ -28,7 +28,7 @@ walker chat {
 
 node Session {
     can generate_result with AgentVisitor entry {
-        if [-->](`?BaseAgent) {
+        if [-->](?:BaseAgent) {
             visit [-->];
         } else {
             UI_Agent = self ++> TripIntakeAgent();

--- a/Travel_planner/requirements.txt
+++ b/Travel_planner/requirements.txt
@@ -2,5 +2,5 @@ streamlit
 byllm
 requests
 jaclang
-jac-cloud
+jac-scale
 python-dotenv


### PR DESCRIPTION
- Updated the initialization of the `Model` in both `agent_brain.jac` and `agent_core.jac` to use the `config` parameter for setting `verbose` instead of a direct argument, aligning with the latest stack.
- Refactored agent traversal and connection syntax throughout `agent_core.jac` and `main.jac` to use the new `?:Type` pattern instead of the deprecated ``'?Type`` pattern. Update `root with new type Root.
- Replaced the `jac-cloud` dependency with `jac-scale` in `requirements.txt`.