### PR TITLE
fix: Update jac-mcp-chatbot backend with the latest jaseci stack

### DIFF
--- a/jac-mcp-chatbot/README.md
+++ b/jac-mcp-chatbot/README.md
@@ -68,7 +68,7 @@ This project demonstrates how to build a modern chatbot capable of interacting w
 2. Start the main application:
 
    ```bash
-   jac serve server.jac
+   jac start server.jac
    ```
 
 3. Launch the web interface:

--- a/jac-mcp-chatbot/server.impl.jac
+++ b/jac-mcp-chatbot/server.impl.jac
@@ -20,7 +20,7 @@ impl ImageChat.chat {
     img_path = visitor.file_path;
     response = self.respond_with_image(
         img=Image(img_path),
-        text=visitor.message,
+        text=Text(visitor.message),
         chat_history=visitor.chat_history
     );
 
@@ -34,7 +34,7 @@ impl VideoChat.chat {
     video_path = visitor.file_path;
     response = self.respond_with_video(
         video=Video(video_path),
-        text=visitor.message,
+        text=Text(visitor.message),
         chat_history=visitor.chat_history
     );
 

--- a/jac-mcp-chatbot/server.jac
+++ b/jac-mcp-chatbot/server.jac
@@ -6,7 +6,7 @@ import base64;
 import mcp_client;
 
 glob rag_engine:RagEngine = RagEngine();
-glob llm = Model(model_name='gpt-4o-mini', verbose=True);
+glob llm = Model(model_name='gpt-4o-mini',config={"verbose": False});
 glob MCP_SERVER_URL: str = os.getenv('MCP_SERVER_URL', 'http://localhost:8899/mcp');
 
 
@@ -31,20 +31,20 @@ walker infer {
     has file_path: str = "";
     has response: str = "";
 
-    can init_router with `root entry {
-        visit [-->](`?Router) else {
+    can init_router with Root entry {
+        visit [-->](?:Router) else {
             router_node = here ++> Router();
-            router_node ++> RagChat();
-            router_node ++> QAChat();
-            router_node ++> ImageChat();
-            router_node ++> VideoChat();
+            router_node ++> RagChat(chat_type=ChatType.RAG);
+            router_node ++> QAChat(chat_type=ChatType.QA);
+            router_node ++> ImageChat(chat_type=ChatType.IMAGE);
+            router_node ++> VideoChat(chat_type=ChatType.VIDEO);
             visit router_node;
         }
     }
     can route with Router entry {
         classification = here.classify(message = self.message);
         print("Routing message:", self.message, "to chat type:", classification);
-        visit [-->](`?Chat)(?chat_type==classification);
+        visit [-->](?:Chat, chat_type==classification);
     }
 }
 
@@ -99,8 +99,8 @@ walker interact {
     has chat_history: list[dict] = [];
     has file_path: str = "";
 
-    can init_session with `root entry {
-        visit [-->](`?Session)(?id == self.session_id) else {
+    can init_session with Root entry {
+        visit [-->](?:Session)(?id == self.session_id) else {
             session_node = here ++> Session(id=self.session_id, chat_history=[], file_path=self.file_path, status=1);
             visit session_node;
         }
@@ -131,5 +131,5 @@ walker upload_file {
     has file_data: str;
     has session_id: str;
 
-    can save_doc with `root entry;
+    can save_doc with Root entry;
 }

--- a/jac-mcp-chatbot/tools.jac
+++ b/jac-mcp-chatbot/tools.jac
@@ -2,7 +2,7 @@ import os;
 import requests;
 import from langchain_community.document_loaders {PyPDFDirectoryLoader, PyPDFLoader}
 import from langchain_text_splitters {RecursiveCharacterTextSplitter}
-import from langchain.schema.document {Document}
+import from langchain_core.documents {Document}
 import from langchain_openai {OpenAIEmbeddings}
 import from langchain_chroma {Chroma}
 


### PR DESCRIPTION
* Changed the `text` parameter in both `ImageChat.chat` and `VideoChat.chat` to explicitly use the `Text` type, ensuring message content is consistently typed throughout the codebase.
* Updated walker and router initialization and routing logic to use `Root entry` and the `?:` syntax for more robust and explicit node selection.
* Modified the instantiation of the `llm` global to pass the `verbose` flag via the `config` dictionary.
* Updated the import for the `Document` class to use `langchain_core.documents` instead of `langchain.schema.document`, aligning with the latest library structure.
* Fixed the command in the `README.md` to use `jac start` instead of the outdated `jac serve`.