### PR TITLE
fix: Update aider-genius application with the latest jaseci stack

### DIFF
--- a/aider-genius/aider/checkpoints/genius_mode.jac
+++ b/aider-genius/aider/checkpoints/genius_mode.jac
@@ -160,7 +160,7 @@ class GeniusAgent {
         issues = [];
         if (self.coder.auto_lint and self.coder.abs_fnames ) {
             try {
-                for fname in <>list(self.coder.abs_fnames) {
+                for fname in `list(self.coder.abs_fnames) {
                     lint_result = self.coder.linter.lint(fname);
                     if lint_result {
                         issues.append(
@@ -684,7 +684,7 @@ class GeniusAgent {
             queries.append(f" 'python error solution ' {error_key_terms} ");
         }
         unique_queries = [];
-        seen = <>set();
+        seen = `set();
         for query in queries {
             if (query.lower() not in seen) {
                 unique_queries.append(query);
@@ -711,7 +711,7 @@ class GeniusAgent {
                 'Checking code style and syntax'
             );
             try {
-                self.coder.commands.cmd_lint(fnames=<>list(self.coder.abs_fnames));
+                self.coder.commands.cmd_lint(fnames=`list(self.coder.abs_fnames));
                 lint_passed = (self.coder.lint_outcome is not False);
                 validation_results['lint_passed'] = lint_passed;
                 if not lint_passed {
@@ -815,7 +815,7 @@ class GeniusAgent {
 
     """Generate a comprehensive report of the agent's work"""
     def generate_report(self: Any) -> str {
-        <>report =
+        `report =
 
             ['Genius Agent Execution Report',
             ('=' * 40),
@@ -826,16 +826,16 @@ class GeniusAgent {
             '',
             'Completed Tasks:'];
         for task in self.completed_tasks {
-            <>report.append(f" '  ' {task['name']} ");
+            `report.append(f" '  ' {task['name']} ");
         }
         if self.failed_tasks {
-            <>report.append('\nFailed Tasks:');
+            `report.append('\nFailed Tasks:');
             for task in self.failed_tasks {
-                <>report.append(f" '  ' {task['name']} ");
+                `report.append(f" '  ' {task['name']} ");
             }
         }
         if self.validation_results {
-            <>report.extend(
+            `report.extend(
 
                 ['\nFinal Validation Results:',
                 f" '  Lint: ' {'✅' if self.validation_results['lint_passed'] else '❌'} ",
@@ -843,7 +843,7 @@ class GeniusAgent {
                 f" '  Security: ' {'✅' if self.validation_results['security_passed'] else '❌'} "]
             );
         }
-        return '\n'.join(<>report);
+        return '\n'.join(`report);
     }
 
     """Main execution loop for the Genius Agent. Implements the complete agent architecture with feedback loops."""
@@ -901,8 +901,8 @@ class GeniusAgent {
                 self._handle_validation_failure(current_task, validation_details);
             }
         }
-        <>report = self.generate_report();
-        self.coder.io.tool_output(<>report);
+        `report = self.generate_report();
+        self.coder.io.tool_output(`report);
         success =
             ((len(self.completed_tasks) > 0)
             and (not self.validation_results
@@ -976,7 +976,7 @@ class GeniusAgent {
 """Legacy wrapper for backwards compatibility"""
 class GeniusMode(GeniusAgent) {
     def __init__(self: Any, coder: Any, task: Any = None, max_iterations: Any = 5) {
-        <>super().init(coder, task, max_iterations);
+        `super().init(coder, task, max_iterations);
     }
 }
 

--- a/aider-genius/aider/checkpoints/genius_multi.jac
+++ b/aider-genius/aider/checkpoints/genius_multi.jac
@@ -8,7 +8,7 @@ import from pathlib { Path }
 import from typing { Any, Dict, List, Optional, Tuple }
 import from aider.web_search { web_search, create_web_searcher }
 import from mcp_client { list_mcp_tools, call_mcp_tool }
-import from byllm {Model}
+import from byllm.lib {Model}
 
 glob llm = Model(model_name="gpt-4o-mini");
 
@@ -889,7 +889,7 @@ walker GeniusAgent {
     has execution_state: ExecutionState;
 
     # Initialize the agent and start at root
-    can start with `root entry {
+    can start with Root entry {
         # Initialize execution state
         self.execution_state = ExecutionState(
             task_description=self.task,

--- a/aider-genius/aider/checkpoints/genius_osp.jac
+++ b/aider-genius/aider/checkpoints/genius_osp.jac
@@ -5,7 +5,7 @@ import re;
 import from pathlib { Path }
 import from typing { Any, Dict, List, Optional, Tuple }
 import from aider.web_search { web_search, create_web_searcher }
-import from mtllm {Model}
+import from byllm.lib {Model}
 
 with entry {
     try {
@@ -994,7 +994,7 @@ walker GeniusAgent {
     has planning_complete: bool = False;
 
     # Initialize the agent and start at root
-    can start with `root entry {
+    can start with Root entry {
         # Initialize web searcher if available
         if WEB_SEARCH_AVAILABLE and create_web_searcher {
             self.web_searcher = create_web_searcher(print_error=self.coder.io.tool_error);

--- a/aider-genius/aider/genius.jac
+++ b/aider-genius/aider/genius.jac
@@ -8,7 +8,7 @@ import from pathlib { Path }
 import from typing { Any, Dict, List, Optional, Tuple }
 import from aider.web_search { web_search, create_web_searcher }
 import from mcp_client { list_mcp_tools, call_mcp_tool }
-import from byllm {Model}
+import from byllm.lib {Model}
 
 glob llm = Model(model_name="gpt-4o-mini");
 
@@ -771,7 +771,7 @@ walker GeniusAgent {
     has planning_complete: bool = False;
 
     # Initialize the agent and start at root
-    can start with `root entry {
+    can start with Root entry {
         # Set up planning and editor models first
         self.planning_model = Model(model_name="gpt-4.1-mini");
         self.editor_model = Model(model_name="gpt-4.1-mini");

--- a/aider-genius/aider/test.jac
+++ b/aider-genius/aider/test.jac
@@ -1,4 +1,4 @@
-import from mtllm { Model }
+import from byllm.lib { Model }
 import from aider.web_search { web_search, create_web_searcher, WebSearcher }
 import from typing { Optional, Dict, Any }
 import from mcp_client { list_mcp_tools, call_mcp_tool }
@@ -6,7 +6,7 @@ import mcp_client;
 
 
 with entry {
-    planning_model = Model(model_name="gemini/gemini-2.5-flash", temperature=0.1,verbose=True);
+    planning_model = Model(model_name="gemini/gemini-2.5-flash",config={"temperature": 0.1, "verbose": True});
 }
 
 # Perform a web search using the Serper API.

--- a/aider-genius/aider/web_search.jac
+++ b/aider-genius/aider/web_search.jac
@@ -96,7 +96,7 @@ class WebSearcher {
         data: Dict[(str, Any)],
         num_results: int
     ) -> str {
-        if not isinstance(data, <>dict) {
+        if not isinstance(data, dict) {
             return 'Invalid search response format';
         }
         organic_results = data.get('organic', []);


### PR DESCRIPTION
* Standardized all imports of the `Model` class to use `from byllm.lib {Model}` instead of previous imports from `byllm` or `mtllm` in `genius.jac`, `genius_multi.jac`, `genius_osp.jac`, and `test.jac`.
* Replaced incorrect use of angle brackets (`<>`) for list and set initialization with backticks (e.g., `list(...)`, `set(...)`, and variable assignment) throughout `genius_mode.jac`. 
* Fixed a type check by removing angle brackets from `dict` in an `isinstance` call in `web_search.jac`.
* Updated agent entry points to use `Root entry` instead of ``root entry`` in `genius.jac`, `genius_multi.jac`, and `genius_osp.jac` for better clarity and consistency. 
