### PR TITLE
fix: Update the smart-learning-companion application with the latest jaseci stack

### DIFF
--- a/smart-learning-companion/README.md
+++ b/smart-learning-companion/README.md
@@ -74,23 +74,23 @@ An intelligent, AI-powered educational assistant built with **Jac-Client** and *
 
    Install the required packages using Jac CLI:
    ```bash
-   jac add --cl
+   jac add --npm
    ```
    Or if you want to install one at a time,
    ```bash
-   jac add --cl @mui/material@7.3.5 
-   jac add --cl @mui/icons-material@7.3.5 
-   jac add --cl @mui/lab@7.0.1-beta.19
-   jac add --cl @emotion/react@11.14.0 
-   jac add --cl @emotion/styled@11.14.1
-   jac add --cl framer-motion@12.23.24
+   jac add --npm @mui/material@7.3.5 
+   jac add --npm @mui/icons-material@7.3.5 
+   jac add --npm @mui/lab@7.0.1-beta.19
+   jac add --npm @emotion/react@11.14.0 
+   jac add --npm @emotion/styled@11.14.1
+   jac add --npm framer-motion@12.23.24
    ```
    
    > **Note**: React, React-DOM, React Router, and core build tools (Vite, Babel, TypeScript) are automatically included with Jac-Client.
 
 5. **Start the application**
    ```bash
-   jac serve src/app.jac
+   jac start src/app.jac
    ```
 
 6. **Open your browser**

--- a/smart-learning-companion/src/app.jac
+++ b/smart-learning-companion/src/app.jac
@@ -22,7 +22,7 @@ walker learn_topic {
         )
     );
 
-    can learn with `root entry {
+    can learn with Root entry {
         explanation = self.explain_topic(topic=self.topic, level=self.level);
         report {"topic": self.topic, "level": self.level, "explanation": explanation} ;
     }
@@ -41,7 +41,7 @@ walker generate_quiz {
         )
     );
 
-    can generate with `root entry {
+    can generate with Root entry {
         quiz_data = self.create_quiz(
             topic=self.topic,
             difficulty=self.difficulty,
@@ -67,7 +67,7 @@ walker chat_tutor {
         )
     );
 
-    can chat with `root entry {
+    can chat with Root entry {
         history_text = "\n".join(
             [f"{msg['role']}: {msg['content']}" for msg in self.context[-6:]]
         );
@@ -90,7 +90,7 @@ walker suggest_learning_path {
         )
     );
 
-    can suggest with `root entry {
+    can suggest with Root entry {
         path_data = self.create_learning_path(
             goal=self.goal, knowledge_level=self.current_knowledge
         );


### PR DESCRIPTION
* Updated `README.md` to use `jac add --npm` instead of the deprecated `jac add --cl` for installing dependencies, and changed the application start command from `jac serve` to `jac start` for better alignment with Jac-Client's latest practices.

* Replaced backtick syntax for root entry invocations (e.g., `` `root entry { ``) with the correct `Root entry`