### PR TITLE
Fix Sidebar Chat History Layout 

### DIFF
--- a/jac-gpt-fullstack/components/Sidebar.cl.jac
+++ b/jac-gpt-fullstack/components/Sidebar.cl.jac
@@ -278,7 +278,7 @@ def:pub Sidebar(
     sessionsContent = <Text size="sm" c={MUTED2} ta="center" py="lg">No chat history yet</Text>;
 
     if isExpanded and chatSessions.length > 0 {
-        sessionsContent = <Stack gap={4}>
+        sessionsContent = <Stack gap={8}>
             {chatSessions.map(lambda session: any -> any {
                 isCurrentSession = session.id == currentSessionId;
                 isHovered = hoveredSessionId == session.id;
@@ -365,9 +365,9 @@ def:pub Sidebar(
 
     chatSessionsList = None;
     if isExpanded {
-        chatSessionsList = <Box px="md" style={{"flex": "1", "overflow": "hidden"}}>
+        chatSessionsList = <Box px="md" style={{"height": "100%", "display": "flex", "flexDirection": "column", "overflow": "hidden"}}>
             <Text size="xs" fw={600} c={MUTED} tt="uppercase" mb="sm">Recent Chats</Text>
-            <ScrollArea style={{"height": "100%"}} type="scroll">
+            <ScrollArea style={{"flex": "1", "minHeight": "0"}} type="scroll">
                 {sessionsContent}
             </ScrollArea>
         </Box>;


### PR DESCRIPTION
## Changes

Sidebar Chat History Layout Fix (`components/Sidebar.cl.jac`)

**Problem:**  
The chat history list in the left sidebar became visually overcrowded when many sessions existed. Items were cramped with no proper scroll boundary, and the `ScrollArea` never activated because `flex: 1` on the outer container had no effect (its parent was not a flex container), causing `height: 100%` on the `ScrollArea` to resolve to zero.

**Fix:**
- Changed the outer `chatSessionsList` Box to use `height: 100%` with `display: flex` and `flexDirection: column` .
- Changed `ScrollArea` to use `flex: 1` with `minHeight: 0` — the critical property that allows a flex child to shrink below its content size and enable true overflow scrolling.
- Increased `Stack` gap from `4px` to `8px` for consistent breathing room between items.

### Before — Overcrowded sidebar with no scroll

> 
<img width="1919" height="894" alt="image" src="https://github.com/user-attachments/assets/46ec19f9-d64e-4f1d-81a5-a76ef088aa29" />


---

### After — Clean sidebar with proper scroll and spacing

> 
<img width="1919" height="897" alt="image" src="https://github.com/user-attachments/assets/96301e02-166a-47ba-833e-fc9d8d86d9da" />

---
