### PR TITLE
fix(jac-gpt): install jaseci from upstream main instead of fork

### DIFF
--- a/jac-gpt-fullstack/jac.toml
+++ b/jac-gpt-fullstack/jac.toml
@@ -49,7 +49,8 @@ base_route_app = "app"
 [plugins.scale.kubernetes]
 app_name = "jac-gpt-test"
 namespace = "jac-gpt-test"
-# Probes — app needs ~5-8 min to clone repo, install jaseci, and compile
+jaseci_repo_url = "https://github.com/jaseci-labs/jaseci.git"
+jaseci_branch = "main"
 liveness_initial_delay = 600
 liveness_period = 30
 liveness_failure_threshold = 10

--- a/jac-gpt-fullstack/jac.toml
+++ b/jac-gpt-fullstack/jac.toml
@@ -49,8 +49,6 @@ base_route_app = "app"
 [plugins.scale.kubernetes]
 app_name = "jac-gpt-test"
 namespace = "jac-gpt-test"
-jaseci_repo_url = "https://github.com/udithishanka/jaseci.git"
-jaseci_branch = "feat/add-jac-mcp-to-scale-deployments"
 # Probes — app needs ~5-8 min to clone repo, install jaseci, and compile
 liveness_initial_delay = 600
 liveness_period = 30


### PR DESCRIPTION
## Summary
- jac-gpt-fullstack/jac.toml currently pins the in-pod jaseci install to udithishanka/jaseci#feat/add-jac-mcp-to-scale-deployments via jaseci_repo_url + jaseci_branch.
- Drop those overrides so the pod falls back to the jac-scale defaults (jaseci-labs/jaseci#main).

## Deploy plan
- Merge this PR.
- Trigger .github/workflows/deploy.yml via workflow_dispatch (or push a jac-gpt-* tag) to redeploy.
- The deploy workflow runs jac start main.jac --scale --experimental, which will roll the existing jac-gpt-test pod onto a fresh one that clones jaseci-labs/jaseci#main during boot.

## Test plan
- [ ] Confirm workflow run succeeds end-to-end.
- [ ] kubectl get pods -n jac-gpt-test shows the new pod 1/1 Ready (probes already allow ~10 min for clone + install).
- [ ] App URL responds at /docs.