### PR TITLE
fix(jac-gpt-deploy): clone jac-scale from upstream main on the runner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,13 +44,18 @@ jobs:
         with:
           python-version: '3.12'
 
-      # Install required packages (including app dependencies for local validation)
-      # Install jac-scale from fork branch that includes jac-mcp in deployment pipeline
+      # Install required packages (including app dependencies for local validation).
+      # Pulled from jaseci-labs/jaseci main so the runner's jac-scale matches what
+      # the pod will clone via [plugins.scale.kubernetes].jaseci_repo_url/branch.
+      # Using fork-side jac-scale here generated a stale install command
+      # (pip install -e ./jac-scale, no extras) against an upstream-main runtime
+      # that now requires pymongo via jac-scale[data] — the pod ImportErrored
+      # on JacScaleUserManager boot.
       - name: Install Jaseci packages
         run: |
           pip install --upgrade pip
           pip install jaclang jac-client byllm
-          git clone --depth 1 --branch feat/add-jac-mcp-to-scale-deployments https://github.com/udithishanka/jaseci.git /tmp/jaseci
+          git clone --depth 1 --branch main https://github.com/jaseci-labs/jaseci.git /tmp/jaseci
           pip install -e /tmp/jaseci/jac-scale
           pip install -e /tmp/jaseci/jac-mcp
 


### PR DESCRIPTION
## Summary
- The deploy workflow's Install Jaseci packages step cloned jac-scale from udithishanka/jaseci#feat/add-jac-mcp-to-scale-deployments on the GH runner.
- That older template generates 'pip install -e ./jac-scale' (no extras) inside the pod init script.
- After PR #618 switched the pod's in-cluster clone to jaseci-labs/jaseci#main, upstream's runtime started require_optional('pymongo', 'data') in JacScaleUserManager.__post_init__, and the pod crashed with ImportError on every boot.
- Upstream main's template emits 'jac install -e ./jac-scale --extras all' which pulls pymongo in. Switching the runner clone to jaseci-labs/jaseci#main lines runner and pod up on the same template.

## Repro
- Workflow run https://github.com/jaseci-labs/Agentic-AI/actions/runs/26038169179 (post-#618)
- Pod jac-gpt-test-75d5c9db56-s5gs4 → CrashLoopBackOff with the pymongo ImportError above

## Test plan
- [ ] Merge this PR.
- [ ] Re-run Deploy JAC-GPT Fullstack with jac-scale via workflow_dispatch on main.
- [ ] kubectl get pods -n jac-gpt-test shows the new pod 1/1 Ready.