### PR TITLE
pin: clone jaseci from fix/byllm-streaming-cross-context-token-reset for jac-gpt-test

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,18 +45,18 @@ jobs:
           python-version: '3.12'
 
       # Install required packages (including app dependencies for local validation).
-      # Pulled from jaseci-labs/jaseci main so the runner's jac-scale matches what
-      # the pod will clone via [plugins.scale.kubernetes].jaseci_repo_url/branch.
-      # Using fork-side jac-scale here generated a stale install command
-      # (pip install -e ./jac-scale, no extras) against an upstream-main runtime
-      # that now requires pymongo via jac-scale[data] — the pod ImportErrored
-      # on JacScaleUserManager boot.
+      # The runner's jac-scale must match what the pod clones via
+      # [plugins.scale.kubernetes].jaseci_repo_url/branch, otherwise the install
+      # command generated for the pod drifts from the runtime that gets cloned.
+      # Temporarily pinned to udithishanka/jaseci fix/byllm-streaming-cross-context-token-reset
+      # (jaseci-labs/jaseci#6016). Revert to jaseci-labs/jaseci main once merged.
       - name: Install Jaseci packages
         run: |
           pip install --upgrade pip
           pip install jaclang jac-client byllm
-          git clone --depth 1 --branch main https://github.com/jaseci-labs/jaseci.git /tmp/jaseci
+          git clone --depth 1 --branch fix/byllm-streaming-cross-context-token-reset https://github.com/udithishanka/jaseci.git /tmp/jaseci
           pip install -e /tmp/jaseci/jac-scale
+          pip install -e /tmp/jaseci/jac-byllm
           pip install -e /tmp/jaseci/jac-mcp
 
       # Install app dependencies (required for jac start to validate main.jac locally)

--- a/jac-gpt-fullstack/jac.toml
+++ b/jac-gpt-fullstack/jac.toml
@@ -49,8 +49,10 @@ base_route_app = "app"
 [plugins.scale.kubernetes]
 app_name = "jac-gpt-test"
 namespace = "jac-gpt-test"
-jaseci_repo_url = "https://github.com/jaseci-labs/jaseci.git"
-jaseci_branch = "main"
+# Temporarily pinned to the byllm streaming cross-Context fix
+# (jaseci-labs/jaseci#6016). Revert to jaseci-labs/jaseci main once merged.
+jaseci_repo_url = "https://github.com/udithishanka/jaseci.git"
+jaseci_branch = "fix/byllm-streaming-cross-context-token-reset"
 liveness_initial_delay = 600
 liveness_period = 30
 liveness_failure_threshold = 10


### PR DESCRIPTION
## Summary

Temporary pin to unblock streaming chat on jac-gpt-test.

The deployed pod's SSE producer crashes with `ValueError: Token was created in a different Context` on every streaming response, so the chat UI sees the envelope but no tokens. Root-caused upstream and fixed in jaseci-labs/jaseci#6016. Until that lands, point this deployment at the fork branch carrying the fix.

## Changes

- `jac-gpt-fullstack/jac.toml`: `jaseci_repo_url` → `https://github.com/udithishanka/jaseci.git`, `jaseci_branch` → `fix/byllm-streaming-cross-context-token-reset`. The pod's experimental runtime setup will clone this branch on boot.
- `.github/workflows/deploy.yml`: the runner now clones the same fork branch (instead of jaseci-labs/jaseci main) so its locally-installed `jac-scale` matches the runtime the pod will actually run. Adds editable install of `jac-byllm` from the same clone for consistency.

## Follow-up

Revert both files back to `jaseci-labs/jaseci` main once jaseci-labs/jaseci#6016 is merged.

## Related

- Upstream PR: jaseci-labs/jaseci#6016
- Upstream issue: jaseci-labs/jaseci#6015