### PR TITLE
fix(streaming): stop pre-framing SSE payloads in stream_chat_response

### DIFF
--- a/jac-gpt-fullstack/services/jacServer.impl.jac
+++ b/jac-gpt-fullstack/services/jacServer.impl.jac
@@ -3,13 +3,17 @@ import os;
 import from datetime {datetime}
 import from byllm.types { StreamEvent }
 
-# Shared helper function for streaming responses with SSE format
+# Shared helper that yields raw event dicts. jac-scale's sse_frame_stream
+# JSON-encodes each yielded item and wraps it in `data: ... \n\n`, so this
+# generator must not pre-frame the SSE payload itself. Doing so produces
+# `data: "data: {...}\\n\\n"` on the wire, the client's JSON.parse fails on
+# the inner `data: ...` prefix, and no chunks render in the UI.
 def stream_chat_response(response_generator: any, visitor: any) -> any {
    print("Starting response streaming...");
 
    response = "";
    for event in response_generator {
-      yield f"data: {json.dumps({'type': event.event_type, 'data': event.data})}\n\n";
+      yield {"type": event.event_type, "data": event.data};
       if event.event_type == "chunk" {
          chunk_data = event.data or {};
          response += chunk_data.get("content", "");


### PR DESCRIPTION
## Summary

`stream_chat_response` in `jacServer.impl.jac` was yielding pre-formatted SSE strings (`data: {...}\n\n`). jac-scale's `sse_frame_stream` then JSON-encodes whatever you yield and wraps it in another `data: ... \n\n` frame, so each chunk hit the wire double-wrapped:

```
data: \"data: {\\\"type\\\": \\\"chunk\\\", \\\"data\\\": {\\\"content\\\": \\\"...\\\"}}\\n\\n\"
```

The frontend (`jacService.cl.jac`) strips the outer `data:` and runs `JSON.parse` on the remainder, but the remainder starts with `data: ` and is not valid JSON. Every event falls into the parse_error branch silently. User-visible result: chat sends a message, sees the streaming envelope appear, and zero chunks ever render. That is the bug visible on jac-gpt-test today.

## Fix

Yield raw event dicts and let `sse_frame_stream` do the framing.

```jac
- yield f\"data: {json.dumps({'type': event.event_type, 'data': event.data})}\\n\\n\";
+ yield {\"type\": event.event_type, \"data\": event.data};
```

## Verification

Direct curl against https://jac-gpt.jaseci.org/walker/interact pre-fix shows the double-wrapped frames cited above. Post-fix expectation is single-frame SSE that the existing client parser already handles correctly (it has been working for `tool_call` / `tool_result` etc. that aren't sourced from the byllm chunk stream).

## Related

- Backend streaming unblocker: jaseci-labs/jaseci#6016 (already merged on the running pod via #620)