### PR TITLE
Switch jac-gpt deploy off fork to jaseci-labs/jaseci main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,13 +48,11 @@ jobs:
       # The runner's jac-scale must match what the pod clones via
       # [plugins.scale.kubernetes].jaseci_repo_url/branch, otherwise the install
       # command generated for the pod drifts from the runtime that gets cloned.
-      # Temporarily pinned to udithishanka/jaseci fix/byllm-streaming-cross-context-token-reset
-      # (jaseci-labs/jaseci#6016). Revert to jaseci-labs/jaseci main once merged.
       - name: Install Jaseci packages
         run: |
           pip install --upgrade pip
           pip install jaclang jac-client byllm
-          git clone --depth 1 --branch fix/byllm-streaming-cross-context-token-reset https://github.com/udithishanka/jaseci.git /tmp/jaseci
+          git clone --depth 1 --branch main https://github.com/jaseci-labs/jaseci.git /tmp/jaseci
           pip install -e /tmp/jaseci/jac-scale
           pip install -e /tmp/jaseci/jac-byllm
           pip install -e /tmp/jaseci/jac-mcp

--- a/jac-gpt-fullstack/jac.toml
+++ b/jac-gpt-fullstack/jac.toml
@@ -49,10 +49,8 @@ base_route_app = "app"
 [plugins.scale.kubernetes]
 app_name = "jac-gpt-test"
 namespace = "jac-gpt-test"
-# Temporarily pinned to the byllm streaming cross-Context fix
-# (jaseci-labs/jaseci#6016). Revert to jaseci-labs/jaseci main once merged.
-jaseci_repo_url = "https://github.com/udithishanka/jaseci.git"
-jaseci_branch = "fix/byllm-streaming-cross-context-token-reset"
+jaseci_repo_url = "https://github.com/jaseci-labs/jaseci.git"
+jaseci_branch = "main"
 liveness_initial_delay = 600
 liveness_period = 30
 liveness_failure_threshold = 10


### PR DESCRIPTION
byllm streaming cross-Context token-reset fix (#6604) is merged to main, so the temporary pin to udithishanka/jaseci is no longer needed. Points both the pod runtime clone (jac.toml) and the CI runner's jac-scale install (deploy.yml) at jaseci-labs/jaseci main.