### PR TITLE
Fix jac-gpt deploy install for jaseci main plugin layout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,9 +53,9 @@ jobs:
           pip install --upgrade pip
           pip install jaclang jac-client byllm
           git clone --depth 1 --branch main https://github.com/jaseci-labs/jaseci.git /tmp/jaseci
-          pip install -e /tmp/jaseci/jac-scale
-          pip install -e /tmp/jaseci/jac-byllm
-          pip install -e /tmp/jaseci/jac-mcp
+          # Plugins ship only a jac.toml (no pyproject.toml) on main, so they
+          # must be installed via `jac install -e`, not `pip install -e`.
+          jac install -e /tmp/jaseci/jac-scale /tmp/jaseci/jac-byllm /tmp/jaseci/jac-mcp
 
       # Install app dependencies (required for jac start to validate main.jac locally)
       - name: Install app dependencies


### PR DESCRIPTION
Follow-up to #650. On jaseci-labs/jaseci main the plugins (jac-scale, jac-byllm, jac-mcp) ship only a jac.toml (no pyproject.toml), so the deploy's `pip install -e` step fails with 'does not appear to be a Python project'. Switch to `jac install -e`, which reads each plugin's jac.toml.