### PR TITLE
fix(jac-gpt): don't crash startup when MCP tool categorization LLM call fails

### DIFF
--- a/jac-gpt-fullstack/services/jacServer.jac
+++ b/jac-gpt-fullstack/services/jacServer.jac
@@ -10,6 +10,12 @@ import from services.rag_engine {RagEngine, load_config}
 import from services.mcp_client {McpClient}
 import from datetime {datetime}
 
+# Load environment variables (API keys, model overrides) up front, before any
+# LLM-backed initialization runs, so credentials are available to the calls below.
+with entry {
+    load_dotenv(override=True);
+}
+
 # Long-lived MCP client subprocess (stdio JSON-RPC)
 glob mcp_client: McpClient = McpClient();
 glob available_mcp_tools_descriptions: str = mcp_client.get_tool_descriptions() if mcp_client.get_tools_length() > 0 else "";
@@ -17,12 +23,21 @@ glob available_mcp_tools_descriptions: str = mcp_client.get_tool_descriptions() 
 def categorized_mcp_tools(mcp_tools: str) -> dict[str, list[str]] by llm();
 def reorder_categorized_mcp_tools(categorized_tools: dict[str, list[str]]) -> dict[str, list[str]] by llm();
 
-glob mcp_tools_cache: dict[str, list[str]] = reorder_categorized_mcp_tools(categorized_mcp_tools(available_mcp_tools_descriptions)) if available_mcp_tools_descriptions else {"syntax_tools": [], "validation_tools": [], "other_tools": []};
-
-with entry {
-    load_dotenv(override=True);
-    print(f"[MCP TOOLS CACHE]: syntax_tools={len(mcp_tools_cache.get('syntax_tools', []))}, validation_tools={len(mcp_tools_cache.get('validation_tools', []))}, other_tools={len(mcp_tools_cache.get('other_tools', []))}");
-    print(f"[MCP TOOLS CACHE DETAILS]: {json.dumps(mcp_tools_cache, indent=2)}");
+# Categorizing MCP tools needs a working LLM. Build the cache defensively so a
+# missing API key or an unreachable LLM degrades to an empty cache instead of
+# crashing server startup. The MCP chat abilities read this via .get(..., []),
+# so an empty cache is safe. Initialized after `llm` is configured (see below).
+def build_mcp_tools_cache() -> dict[str, list[str]] {
+    empty = {"syntax_tools": [], "validation_tools": [], "other_tools": []};
+    if not available_mcp_tools_descriptions {
+        return empty;
+    }
+    try {
+        return reorder_categorized_mcp_tools(categorized_mcp_tools(available_mcp_tools_descriptions));
+    } except Exception as e {
+        print(f"[MCP TOOLS CACHE] LLM categorization unavailable, continuing with empty cache: {e}");
+        return empty;
+    }
 }
 
 # Load configuration
@@ -36,6 +51,14 @@ glob faiss_path: str = os.path.join(services_dir, app_config.get("paths", {}).ge
 
 glob model_name: str = os.environ.get("MODEL", app_config.get("llm", {}).get("model_name", "gpt-4.1-mini"));
 glob llm = Model(model_name=model_name);
+
+# Built now that `llm` and the environment are ready; never fails server startup.
+glob mcp_tools_cache: dict[str, list[str]] = build_mcp_tools_cache();
+
+with entry {
+    print(f"[MCP TOOLS CACHE]: syntax_tools={len(mcp_tools_cache.get('syntax_tools', []))}, validation_tools={len(mcp_tools_cache.get('validation_tools', []))}, other_tools={len(mcp_tools_cache.get('other_tools', []))}");
+}
+
 glob embedding_model = SentenceTransformer('all-MiniLM-L6-v2');
         
 glob rag_engine: RagEngine = RagEngine(


### PR DESCRIPTION
## Problem

The jaseci `test-pypi-build` CI job (Run tests for jaseci) has been red on `main` since [jaseci-labs/jaseci#7042](https://github.com/jaseci-labs/jaseci/pull/7042), failing at **"Wait for jac-gpt server to be ready"** ([example run](https://github.com/jaseci-labs/jaseci/actions/runs/28434365105/job/84274614427)). The jac-gpt server never binds its port and the wait step times out.

That job scaffolds jac-gpt from the published jacpack (generated from this `jac-gpt-fullstack/`) and runs `jac start main.jac`.

## Root cause

`services/jacServer.jac` made a blocking ``by llm()`` call (`categorized_mcp_tools`) at **module / glob-init time** to categorize the MCP tools, gated on the MCP client having discovered tools:

```jac
glob mcp_tools_cache: dict[str, list[str]] =
    reorder_categorized_mcp_tools(categorized_mcp_tools(available_mcp_tools_descriptions))
    if available_mcp_tools_descriptions else { ... };
```

This call was **dormant** until #7042: jac-gpt has no `jac-mcp` dependency, so before the fold `jac mcp` was an unknown command, `McpClient` got 0 tools, `available_mcp_tools_descriptions` was empty, and the `else` branch ran (no LLM call). #7042 made `jac mcp` a built-in command, so the client now connects, discovers 19 tools, and the ``by llm()`` call fires at startup.

Two further problems made that call fragile:
- it ran **before** `load_dotenv()` and **before** `glob llm = Model(...)`, so it used the default model with credentials not yet loaded;
- any LLM error (no key / unreachable, as in CI) aborted module load, taking down the whole server.

The "missing credentials" error is not jaseci dropping the key: the jac-gpt CI step has no real LLM key, and byllm reads the key from the environment at call time. This is a jac-gpt startup-ordering / resilience bug that #7042 merely exposed.

## Fix

- Load `.env` up front (own `with entry`) so credentials are available before any LLM call.
- Move categorization into a `build_mcp_tools_cache()` helper wrapped in try/except that falls back to the empty cache. The MCP chat abilities already read it via `.get(..., [])`, so an empty cache is safe and the feature degrades gracefully.
- Initialize the cache **after** `glob llm` is configured, so the intended model is used when a key is present.

Net effect: the server always boots; tool categorization is best-effort and only runs when both MCP tools and a working LLM are available.

## Verification

Reproduced and verified against a jac binary built at a red commit (`f6aed53e`, which includes #7042):
- **Before:** ``by llm()`` at glob-init with no key -> `AuthenticationError` -> `Error loading <module>` (server never starts), matching the CI trace.
- **After:** same conditions (no key / invalid key) -> failure is caught, cache falls back to empty, and the module finishes loading ("server booted").
- `jac check` passes on the changed constructs; `jac format` parses the file cleanly.

Once merged to `main`, the `Generate jac-gpt Jacpack` workflow republishes the jacpack to `jaseci-labs/jacpacks`, which unblocks the jaseci CI job.